### PR TITLE
Added serverPort() method returning the listening port of the server

### DIFF
--- a/src/qhttpserver.cpp
+++ b/src/qhttpserver.cpp
@@ -65,6 +65,18 @@ bool QHttpServer::listen(const QHostAddress &address, quint16 port)
     return m_tcpServer->listen(address, port);
 }
 
+quint16 QHttpServer::serverPort() const
+{
+	if( m_tcpServer )
+	{
+		return m_tcpServer->serverPort();
+	}
+	else
+	{
+		return 0;
+	}
+}
+
 bool QHttpServer::listen(quint16 port)
 {
     return listen(QHostAddress::Any, port);

--- a/src/qhttpserver.h
+++ b/src/qhttpserver.h
@@ -119,6 +119,12 @@ public:
     bool listen(const QHostAddress &address = QHostAddress::Any, quint16 port=0);
 
     /*!
+     * The server's listening port.
+     * \return the listening port, 0 if the server wasn't started successfully. 
+     */
+    quint16 serverPort() const;
+
+    /*!
      * Starts the server on @c port listening on all interfaces.
      *
      * \param port Port number on which the server should run.


### PR DESCRIPTION
Added serverPort() method returning the listening port of the server. The method is the only way to find the current port used, when the listen() methods are called with port 0 (find the first available port).
